### PR TITLE
fix subgroup operations on different hardware

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -27,3 +27,4 @@ target_include_directories(enginecore
         PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
         )
+target_link_libraries(enginecore Vulkan::Vulkan)

--- a/multiradixsort/include/MultiRadixSort.h
+++ b/multiradixsort/include/MultiRadixSort.h
@@ -7,7 +7,7 @@
 
 namespace engine {
     class MultiRadixSort {
-        // chainging this to SORT_64BIT requires changes in the two shaders (redefine data type of elements_* buffers to uint64_t)
+        // chainging this to SORT_64BIT requires changes in the two shaders (redefine data type of elements_* buffers to uint64_t) and enabling #extension GL_EXT_shader_explicit_arithmetic_types_int64: require
 #define SORT_32BIT
         // #define SORT_64_BIT
 
@@ -25,7 +25,7 @@ namespace engine {
 
         std::shared_ptr<MultiRadixSortPass> m_pass;
 
-        const uint32_t RADIX_SORT_BINS = 256;
+        const uint32_t RADIX_SORT_BINS = 256; // the GPU scheduling on the host is hardcoded for 256; to change this value, you need to adjust the host code
         const uint32_t NUM_ELEMENTS = 1000000;
 
         const uint32_t NUM_ELEMENTS_BYTES = NUM_ELEMENTS * sizeof(SORT_TYPE);

--- a/multiradixsort/resources/shaders/multi_radixsort.comp
+++ b/multiradixsort/resources/shaders/multi_radixsort.comp
@@ -17,7 +17,7 @@
 layout (local_size_x_id = 0, local_size_x = 256) in; // 256 is the default value, you can update specialization constant 0 from host side
 #define WORKGROUP_SIZE gl_WorkGroupSize.x
 layout (constant_id = 1) const uint RADIX_SORT_BINS = 256; // 256 is the default value, you can update specialization constant 1 from host side
-layout (constant_id = 2) const uint SUBGROUP_SIZE = 8; // 32 is the default value (NVIDIA only!), you can update specialization constant 2 from host side
+layout (constant_id = 2) const uint SUBGROUP_SIZE = 32; // 32 is the default value (NVIDIA only!), you can update specialization constant 2 from host side
 
 layout (push_constant, std430) uniform PushConstants {
     uint g_num_elements;

--- a/multiradixsort/resources/shaders/multi_radixsort.comp
+++ b/multiradixsort/resources/shaders/multi_radixsort.comp
@@ -8,11 +8,16 @@
 #extension GL_KHR_shader_subgroup_arithmetic: enable
 #extension GL_KHR_shader_subgroup_ballot: enable
 
-#define WORKGROUP_SIZE 256// assert WORKGROUP_SIZE >= RADIX_SORT_BINS
-#define RADIX_SORT_BINS 256
-#define SUBGROUP_SIZE 32// 32 NVIDIA; 64 AMD
-
-layout (local_size_x = WORKGROUP_SIZE) in;
+// constraints
+// 1. WORKGROUP_SIZE must be a multiple of 32
+// 2. WORKGROUP_SIZE >= RADIX_SORT_BINS
+// 3. RADIX_SORT_BINS >= SUBGROUP_SIZE
+// 4. SUBGROUP_SIZE must match the vendor specific gl_SubgroupSize (e.g., 32 on NVIDIA), you can query this: https://docs.vulkan.org/refpages/latest/refpages/source/VkPhysicalDeviceSubgroupProperties.html
+// Adjusting the RADIX_SORT_BINS requires updating the scheduling of the passes on the host side!
+layout (local_size_x_id = 0, local_size_x = 256) in; // 256 is the default value, you can update specialization constant 0 from host side
+#define WORKGROUP_SIZE gl_WorkGroupSize.x
+layout (constant_id = 1) const uint RADIX_SORT_BINS = 256; // 256 is the default value, you can update specialization constant 1 from host side
+layout (constant_id = 2) const uint SUBGROUP_SIZE = 8; // 32 is the default value (NVIDIA only!), you can update specialization constant 2 from host side
 
 layout (push_constant, std430) uniform PushConstants {
     uint g_num_elements;
@@ -43,50 +48,54 @@ struct BinFlags {
 shared BinFlags[RADIX_SORT_BINS] bin_flags;
 
 void main() {
-    uint gID = gl_GlobalInvocationID.x;
-    uint lID = gl_LocalInvocationID.x;
-    uint wID = gl_WorkGroupID.x;
-    uint sID = gl_SubgroupID;
-    uint lsID = gl_SubgroupInvocationID;
+    // === global offsets (prefix sum) ===
 
     uint local_histogram = 0;
-    uint prefix_sum = 0;
     uint histogram_count = 0;
-
-    if (lID < RADIX_SORT_BINS) {
-        uint count = 0;
+    if (gl_LocalInvocationID.x < RADIX_SORT_BINS) {
         for (uint j = 0; j < g_num_workgroups; j++) {
-            const uint t = g_histograms[RADIX_SORT_BINS * j + lID];
-            local_histogram = (j == wID) ? count : local_histogram;
-            count += t;
-        }
-        histogram_count = count;
-        const uint sum = subgroupAdd(histogram_count);
-        prefix_sum = subgroupExclusiveAdd(histogram_count);
-        if (subgroupElect()) {
-            // one thread inside the warp/subgroup enters this section
-            sums[sID] = sum;
+            // read histogram counts of all workgroups for our bin (gl_LocalInvocationID.x)
+            const uint t = g_histograms[RADIX_SORT_BINS * j + gl_LocalInvocationID.x];
+            local_histogram = (j == gl_WorkGroupID.x) ? histogram_count : local_histogram;
+            // sum them up to get the global histogram count for our bin
+            histogram_count += t;
         }
     }
+
+    const uint sum = subgroupAdd(histogram_count);
+    const uint prefix_sum = subgroupExclusiveAdd(histogram_count);
+    if (subgroupElect()) {
+        // only the elected thread of a subgroup writes to the array
+        if (gl_SubgroupID < (RADIX_SORT_BINS / SUBGROUP_SIZE)) {
+            // check if the subgroup ID is within the sums array bounds
+            sums[gl_SubgroupID] = sum;
+        }
+    }
+
     barrier();
 
-    if (lID < RADIX_SORT_BINS) {
-        const uint sums_prefix_sum = subgroupBroadcast(subgroupExclusiveAdd(sums[lsID]), sID);
-        const uint global_histogram = sums_prefix_sum + prefix_sum;
-        global_offsets[lID] = global_histogram + local_histogram;
+    if (gl_LocalInvocationID.x < RADIX_SORT_BINS) {
+        // calculate the prefix sum of the subgroup totals using a simple loop
+        // gl_SubgroupID is our current subgroup ID, sum the totals from previous subgroups
+        uint sums_prefix_sum = 0;
+        for (uint i = 0; i < gl_SubgroupID; i++) {
+            sums_prefix_sum += sums[i];
+        }
+        global_offsets[gl_LocalInvocationID.x] = sums_prefix_sum + prefix_sum + local_histogram;
     }
 
-    //     ==== scatter keys according to global offsets =====
-    const uint flags_bin = lID / 32;
-    const uint flags_bit = 1 << (lID % 32);
+    // === scatter keys according to global offsets ===
+
+    const uint flags_bin = gl_LocalInvocationID.x / 32;
+    const uint flags_bit = 1 << (gl_LocalInvocationID.x % 32);
 
     for (uint index = 0; index < g_num_blocks_per_workgroup; index++) {
-        uint elementId = wID * g_num_blocks_per_workgroup * WORKGROUP_SIZE + index * WORKGROUP_SIZE + lID;
+        uint elementId = gl_WorkGroupID.x * g_num_blocks_per_workgroup * WORKGROUP_SIZE + index * WORKGROUP_SIZE + gl_LocalInvocationID.x;
 
         // initialize bin flags
-        if (lID < RADIX_SORT_BINS) {
+        if (gl_LocalInvocationID.x < RADIX_SORT_BINS) {
             for (int i = 0; i < WORKGROUP_SIZE / 32; i++) {
-                bin_flags[lID].flags[i] = 0U;// init all bin flags to 0
+                bin_flags[gl_LocalInvocationID.x].flags[i] = 0U;// init all bin flags to 0
             }
         }
         barrier();

--- a/multiradixsort/resources/shaders/multi_radixsort_histograms.comp
+++ b/multiradixsort/resources/shaders/multi_radixsort_histograms.comp
@@ -5,10 +5,14 @@
 #version 460
 #extension GL_GOOGLE_include_directive: enable
 
-#define WORKGROUP_SIZE 256 // assert WORKGROUP_SIZE >= RADIX_SORT_BINS
-#define RADIX_SORT_BINS 256
-
-layout (local_size_x = WORKGROUP_SIZE) in;
+// constraints
+// 1. WORKGROUP_SIZE must be a multiple of 32
+// 2. WORKGROUP_SIZE >= RADIX_SORT_BINS
+// 3. RADIX_SORT_BINS >= SUBGROUP_SIZE
+// Adjusting the RADIX_SORT_BINS requires updating the scheduling of the passes on the host side!
+layout (local_size_x_id = 0, local_size_x = 256) in; // 256 is the default value, you can update specialization constant 0 from host side
+#define WORKGROUP_SIZE gl_WorkGroupSize.x
+layout (constant_id = 1) const uint RADIX_SORT_BINS = 256; // 256 is the default value, you can update specialization constant 1 from host side
 
 layout (push_constant, std430) uniform PushConstants {
     uint g_num_elements;
@@ -29,18 +33,14 @@ layout (std430, set = 0, binding = 1) buffer histograms {
 shared uint[RADIX_SORT_BINS] histogram;
 
 void main() {
-    uint gID = gl_GlobalInvocationID.x;
-    uint lID = gl_LocalInvocationID.x;
-    uint wID = gl_WorkGroupID.x;
-
     // initialize histogram
-    if (lID < RADIX_SORT_BINS) {
-        histogram[lID] = 0U;
+    if (gl_LocalInvocationID.x < RADIX_SORT_BINS) {
+        histogram[gl_LocalInvocationID.x] = 0U;
     }
     barrier();
 
     for (uint index = 0; index < g_num_blocks_per_workgroup; index++) {
-        uint elementId = wID * g_num_blocks_per_workgroup * WORKGROUP_SIZE + index * WORKGROUP_SIZE + lID;
+        uint elementId = gl_WorkGroupID.x * g_num_blocks_per_workgroup * WORKGROUP_SIZE + index * WORKGROUP_SIZE + gl_LocalInvocationID.x;
         if (elementId < g_num_elements) {
             // determine the bin
             const uint bin = uint(g_elements_in[elementId] >> g_shift) & uint(RADIX_SORT_BINS - 1);
@@ -50,7 +50,7 @@ void main() {
     }
     barrier();
 
-    if (lID < RADIX_SORT_BINS) {
-        g_histograms[RADIX_SORT_BINS * wID + lID] = histogram[lID];
+    if (gl_LocalInvocationID.x < RADIX_SORT_BINS) {
+        g_histograms[RADIX_SORT_BINS * gl_WorkGroupID.x + gl_LocalInvocationID.x] = histogram[gl_LocalInvocationID.x];
     }
 }

--- a/singleradixsort/resources/shaders/single_radixsort.comp
+++ b/singleradixsort/resources/shaders/single_radixsort.comp
@@ -12,12 +12,12 @@
 // 2. WORKGROUP_SIZE >= RADIX_SORT_BINS
 // 3. RADIX_SORT_BINS >= SUBGROUP_SIZE
 // 4. SUBGROUP_SIZE must match the vendor specific gl_SubgroupSize (e.g., 32 on NVIDIA), you can query this: https://docs.vulkan.org/refpages/latest/refpages/source/VkPhysicalDeviceSubgroupProperties.html
-// Adjusting the RADIX_SORT_BINS requires updating the scheduling of the passes on the host gl_SubgroupIDe!
-layout (local_size_x_id = 0, local_size_x = 256) in; // 256 is the default value, you can update specialization constant 0 from host gl_SubgroupIDe
+// Adjusting the RADIX_SORT_BINS requires updating the scheduling of the passes on the host side!
+layout (local_size_x_id = 0, local_size_x = 256) in; // 256 is the default value, you can update specialization constant 0 from host side
 #define WORKGROUP_SIZE gl_WorkGroupSize.x
-layout (constant_id = 1) const uint RADIX_SORT_BINS = 256; // 256 is the default value, you can update specialization constant 1 from host gl_SubgroupIDe
-layout (constant_id = 2) const uint SUBGROUP_SIZE = 32; // 32 is the default value (NVIDIA only!), you can update specialization constant 2 from host gl_SubgroupIDe
-layout (constant_id = 3) const uint ITERATIONS = 4; // 4 is the default value, you can update specialization constant 3 from host gl_SubgroupIDe
+layout (constant_id = 1) const uint RADIX_SORT_BINS = 256; // 256 is the default value, you can update specialization constant 1 from host side
+layout (constant_id = 2) const uint SUBGROUP_SIZE = 32; // 32 is the default value (NVIDIA only!), you can update specialization constant 2 from host side
+layout (constant_id = 3) const uint ITERATIONS = 4; // 4 is the default value, you can update specialization constant 3 from host side
 
 layout (push_constant, std430) uniform PushConstants {
     uint g_num_elements;
@@ -33,7 +33,7 @@ layout (std430, set = 0, binding = 1) buffer elements_out {
 
 shared uint[RADIX_SORT_BINS] histogram;
 shared uint[RADIX_SORT_BINS / SUBGROUP_SIZE] sums;// subgroup reductions
-shared uint[RADIX_SORT_BINS] local_offsets;// local exclusive scan (prefix sum) (ingl_SubgroupIDe subgroups)
+shared uint[RADIX_SORT_BINS] local_offsets;// local exclusive scan (prefix sum) (inside subgroups)
 shared uint[RADIX_SORT_BINS] global_offsets;// global exclusive scan (prefix sum)
 
 struct BinFlags {

--- a/singleradixsort/resources/shaders/single_radixsort.comp
+++ b/singleradixsort/resources/shaders/single_radixsort.comp
@@ -7,13 +7,17 @@
 #extension GL_KHR_shader_subgroup_basic: enable
 #extension GL_KHR_shader_subgroup_arithmetic: enable
 
-#define WORKGROUP_SIZE 256// assert WORKGROUP_SIZE >= RADIX_SORT_BINS
-#define RADIX_SORT_BINS 256
-#define SUBGROUP_SIZE 32// 32 NVIDIA; 64 AMD
-
-#define ITERATIONS 4// 4 iterations, sorting 8 bits per iteration
-
-layout (local_size_x = WORKGROUP_SIZE) in;
+// constraints
+// 1. WORKGROUP_SIZE must be a multiple of 32
+// 2. WORKGROUP_SIZE >= RADIX_SORT_BINS
+// 3. RADIX_SORT_BINS >= SUBGROUP_SIZE
+// 4. SUBGROUP_SIZE must match the vendor specific gl_SubgroupSize (e.g., 32 on NVIDIA), you can query this: https://docs.vulkan.org/refpages/latest/refpages/source/VkPhysicalDeviceSubgroupProperties.html
+// Adjusting the RADIX_SORT_BINS requires updating the scheduling of the passes on the host gl_SubgroupIDe!
+layout (local_size_x_id = 0, local_size_x = 256) in; // 256 is the default value, you can update specialization constant 0 from host gl_SubgroupIDe
+#define WORKGROUP_SIZE gl_WorkGroupSize.x
+layout (constant_id = 1) const uint RADIX_SORT_BINS = 256; // 256 is the default value, you can update specialization constant 1 from host gl_SubgroupIDe
+layout (constant_id = 2) const uint SUBGROUP_SIZE = 32; // 32 is the default value (NVIDIA only!), you can update specialization constant 2 from host gl_SubgroupIDe
+layout (constant_id = 3) const uint ITERATIONS = 4; // 4 is the default value, you can update specialization constant 3 from host gl_SubgroupIDe
 
 layout (push_constant, std430) uniform PushConstants {
     uint g_num_elements;
@@ -29,7 +33,7 @@ layout (std430, set = 0, binding = 1) buffer elements_out {
 
 shared uint[RADIX_SORT_BINS] histogram;
 shared uint[RADIX_SORT_BINS / SUBGROUP_SIZE] sums;// subgroup reductions
-shared uint[RADIX_SORT_BINS] local_offsets;// local exclusive scan (prefix sum) (inside subgroups)
+shared uint[RADIX_SORT_BINS] local_offsets;// local exclusive scan (prefix sum) (ingl_SubgroupIDe subgroups)
 shared uint[RADIX_SORT_BINS] global_offsets;// global exclusive scan (prefix sum)
 
 struct BinFlags {
@@ -40,20 +44,18 @@ shared BinFlags[RADIX_SORT_BINS] bin_flags;
 #define ELEMENT_IN(index, iteration) (iteration % 2 == 0 ? g_elements_in[index] : g_elements_out[index])
 
 void main() {
-    uint lID = gl_LocalInvocationID.x;
-    uint sID = gl_SubgroupID;
-    uint lsID = gl_SubgroupInvocationID;
-
     for (uint iteration = 0; iteration < ITERATIONS; iteration++) {
-        uint shift = 8 * iteration;
+//        const uint shift = 8 * iteration;
+        const uint bits_per_pass = findMSB(RADIX_SORT_BINS); // 8 if RADIX_SORT_BINS is 256
+        const uint shift = bits_per_pass * iteration;
 
         // initialize histogram
-        if (lID < RADIX_SORT_BINS) {
-            histogram[lID] = 0U;
+        if (gl_LocalInvocationID.x < RADIX_SORT_BINS) {
+            histogram[gl_LocalInvocationID.x] = 0U;
         }
         barrier();
 
-        for (uint ID = lID; ID < g_num_elements; ID += WORKGROUP_SIZE) {
+        for (uint ID = gl_LocalInvocationID.x; ID < g_num_elements; ID += WORKGROUP_SIZE) {
             // determine the bin
             const uint bin = uint(ELEMENT_IN(ID, iteration) >> shift) & uint(RADIX_SORT_BINS - 1);
             // increment the histogram
@@ -62,22 +64,29 @@ void main() {
         barrier();
 
         // subgroup reductions and subgroup prefix sums
-        if (lID < RADIX_SORT_BINS) {
-            uint histogram_count = histogram[lID];
-            uint sum = subgroupAdd(histogram_count);
-            uint prefix_sum = subgroupExclusiveAdd(histogram_count);
-            local_offsets[lID] = prefix_sum;
-            if (subgroupElect()) {
-                // one thread inside the warp/subgroup enters this section
-                sums[sID] = sum;
+        uint histogram_count = 0;
+        if (gl_LocalInvocationID.x < RADIX_SORT_BINS) {
+            histogram_count = histogram[gl_LocalInvocationID.x];
+        }
+        uint sum = subgroupAdd(histogram_count);
+        uint prefix_sum = subgroupExclusiveAdd(histogram_count);
+        if (gl_LocalInvocationID.x < RADIX_SORT_BINS) {
+            local_offsets[gl_LocalInvocationID.x] = prefix_sum;
+        }
+        if (subgroupElect()) {
+            // only the elected thread of a subgroup writes to the array
+            if (gl_SubgroupID < (RADIX_SORT_BINS / SUBGROUP_SIZE)) {
+                // check if the subgroup ID is within the sums array bounds
+                sums[gl_SubgroupID] = sum;
             }
         }
+
         barrier();
 
         // global prefix sums (offsets)
-        if (sID == 0) {
+        if (gl_SubgroupID == 0) {
             uint offset = 0;
-            for (uint i = lsID; i < RADIX_SORT_BINS; i += SUBGROUP_SIZE) {
+            for (uint i = gl_SubgroupInvocationID; i < RADIX_SORT_BINS; i += SUBGROUP_SIZE) {
                 global_offsets[i] = offset + local_offsets[i];
                 offset += sums[i / SUBGROUP_SIZE];
             }
@@ -85,18 +94,18 @@ void main() {
         barrier();
 
         //     ==== scatter keys according to global offsets =====
-        const uint flags_bin = lID / 32;
-        const uint flags_bit = 1 << (lID % 32);
+        const uint flags_bin = gl_LocalInvocationID.x / 32;
+        const uint flags_bit = 1 << (gl_LocalInvocationID.x % 32);
 
         for (uint blockID = 0; blockID < g_num_elements; blockID += WORKGROUP_SIZE) {
             barrier();
 
-            const uint ID = blockID + lID;
+            const uint ID = blockID + gl_LocalInvocationID.x;
 
             // initialize bin flags
-            if (lID < RADIX_SORT_BINS) {
+            if (gl_LocalInvocationID.x < RADIX_SORT_BINS) {
                 for (int i = 0; i < WORKGROUP_SIZE / 32; i++) {
-                    bin_flags[lID].flags[i] = 0U;// init all bin flags to 0
+                    bin_flags[gl_LocalInvocationID.x].flags[i] = 0U;// init all bin flags to 0
                 }
             }
             barrier();


### PR DESCRIPTION
fixes #7 (tested on NVIDIA, AMD, and Lavapipe)
- replaced the hardware-dependent `subgroupBroadcast(subgroupExclusiveAdd(sums[lsID]), sID)` with a hardware-agnostic shared memory for loop to avoid out-of-bounds accesses and undefined behavior
- added strict bounds checking
- fixed possible divergent control flow (inactive lanes now safely contribute 0 to the subgroup sums)
- added comments regarding the constraints for WORKGROUP_SIZE, RADIX_SORT_BINS, and SUBGROUP_SIZE
- changed macros for WORKGROUP_SIZE, RADIX_SORT_BINS, and SUBGROUP_SIZ to specialization constants so that they can easily be changed from the host side

fixes are applied both to the single_radixsort and the multi_radixsort

for Lavapipe the following configuration, for example, works now:
- WORKGROUP_SIZE=256 (default), RADIX_SORT_BINS=256 (default), SUBGROUP_SIZE=8 (<-- changed for Lavapipe's smaller subgroup size)